### PR TITLE
Make plugin compatible with Kanboard 1.0.43

### DIFF
--- a/Formatter/TaskGanttLinkAwareFormatter.php
+++ b/Formatter/TaskGanttLinkAwareFormatter.php
@@ -2,7 +2,7 @@
 
 namespace Kanboard\Plugin\Milestone\Formatter;
 
-use Kanboard\Formatter\TaskGanttFormatter;
+use Kanboard\Plugin\Gantt\Formatter\TaskGanttFormatter;
 
 /**
  * Task Gantt Formatter ware of internal links between tasks

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014-2016 Frédéric Guillot
+Copyright (c) 2016-2017 Olivier Maridat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Model/TaskLinkExtModel.php
+++ b/Model/TaskLinkExtModel.php
@@ -6,7 +6,6 @@ use Kanboard\Core\Base;
 use Kanboard\Model\ColumnModel;
 use Kanboard\Model\LinkModel;
 use Kanboard\Model\ProjectModel;
-use Kanboard\Model\TaskLinkModel;
 use Kanboard\Model\TaskModel;
 use Kanboard\Model\UserModel;
 

--- a/Plugin.php
+++ b/Plugin.php
@@ -7,7 +7,6 @@ use Kanboard\Plugin\Milestone\Formatter\TaskGanttLinkAwareFormatter;
 
 class Plugin extends Base
 {
-
     public function initialize()
     {
         $this->hook->on('template:layout:css', array('template' => 'plugins/Milestone/Css/milestone.css'));
@@ -21,7 +20,7 @@ class Plugin extends Base
         });
     }
 
-     public function onStartup()
+    public function onStartup()
     {
         Translator::load($this->languageModel->getCurrentLanguage(), __DIR__.'/Locale');
     }
@@ -58,5 +57,10 @@ class Plugin extends Base
     public function getPluginDescription()
     {
         return t('The Milestone Plugin for Kanboard adds a section for milestones to show their related tasks.');
+    }
+
+    public function getCompatibleVersion()
+    {
+        return '1.0.43';
     }
 }


### PR DESCRIPTION
The Gantt chart is now a plugin since the version 1.0.42.