### PR TITLE
fix milestone detection for renamed links

### DIFF
--- a/Template/task_internal_link/show.php
+++ b/Template/task_internal_link/show.php
@@ -1,6 +1,6 @@
-<?php if (!empty($links['is a milestone of'])): ?>
+<?php if (!empty($links['is a milestone of']) || isset($link_label_list) && isset($link_label_list[9]) && !empty($links[$link_label_list[9]])): ?>
 <?= $this->render('milestone/show', array(
-    'milestone' => $links['is a milestone of'],
+    'milestone' => !empty($links['is a milestone of']) ? $links['is a milestone of']: $links[$link_label_list[9]],
     'task' => $task,
     'project' => $project,
     'editable' => $editable,
@@ -8,6 +8,7 @@
     'link_label_list' => isset($link_label_list) ? $link_label_list : array(),
 )) ?>
 <?php unset($links['is a milestone of']); ?>
+<?php if (isset($link_label_list) && isset($link_label_list[9])): unset($links[$link_label_list[9]]); endif ?>
 <?php endif ?>
 
 <?= $this->render('kanboard:task_internal_link/show', array(


### PR DESCRIPTION
If the milestone link is renamed, the internal links where not displayed as milestone anymore.

In Kanboard itself a milestone is detected by the hardcoded id 9.

https://github.com/kanboard/kanboard/blob/216604a66234c58db4103a148f1a8645e9abfd98/app/Model/TaskFinderModel.php#L89

With this PR the plugin checks also for link id 9